### PR TITLE
Prepare 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,4 +30,8 @@ This file is used to list changes made in each version of the netdata cookbook.
 ## 0.3.1
 - Serge A. Salamanka - use cookbook dependencies with all tested major version numbers
 
+## 0.3.2
+- João Madureira - Support for statsd.d plugin configuration.
+- Serge A. Salamanka - add binary package installation method
+
 - - -

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'kekio.one@gmail.com'
 license          'Apache-2.0'
 description      'Compile, install and configure netdata'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.1'
+version          '0.3.2'
 source_url		   'https://github.com/jmadureira/netdata-cookbook'
 issues_url		   'https://github.com/jmadureira/netdata-cookbook/issues'
 chef_version     '>= 12.5' if respond_to?(:chef_version)


### PR DESCRIPTION
We'd like to use this cookbook from the Supermarket, but we use the binary installation method. Currently we do this via a copy of the current repo via manage.chef.io, which works well enough for the 300+ hosts it runs on, but we'd like to be able to just point to Supermarket. I hope this PR can help us get there. Let me know what else I can do to help out.